### PR TITLE
[Member] 멤버 회원가입 Api 구현 및 JWT 로그인을 위한 Access token, Refresh token 발급, 재발급 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
-build
+build/
+### intellij settings ###
+.gradle
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+out/
 ### intellij settings ###
 .gradle
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
-build
+build/
+### Intellij Settings ###
+.gradle
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,1 @@
-build/
-### Intellij Settings ###
-.gradle
-.idea
+build

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-	java
-	id("org.springframework.boot") version "3.2.1"
-	id("io.spring.dependency-management") version "1.1.4"
+    java
+    id("org.springframework.boot") version "3.2.1"
+    id("io.spring.dependency-management") version "1.1.4"
     id("io.freefair.lombok") version "8.4"
 }
 
@@ -9,18 +9,23 @@ group = "com.climbing"
 version = "0.0.1-SNAPSHOT"
 
 java {
-	sourceCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_21
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation("org.springframework.boot:spring-boot-starter")
+    implementation("org.springframework.boot:spring-boot-starter")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-jdbc")
+    implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("com.auth0:java-jwt:4.2.1")
+
+    implementation("com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.8.1")
 
     runtimeOnly("com.h2database:h2")
 
@@ -29,5 +34,5 @@ dependencies {
 }
 
 tasks.withType<Test> {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/com/climbing/api/controller/MemberController.java
+++ b/src/main/java/com/climbing/api/controller/MemberController.java
@@ -1,15 +1,24 @@
 package com.climbing.api.controller;
 
+import com.climbing.domain.member.MemberDTO;
 import com.climbing.domain.member.MemberService;
-import org.springframework.stereotype.Controller;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+@RestController
 @RequestMapping("/member")
+@RequiredArgsConstructor
 public class MemberController {
-    private MemberService memberService;
 
-    public MemberController(MemberService memberService) {
-        this.memberService = memberService;
+    private final MemberService memberService;
+
+    @PostMapping("/sign-up")
+    public String signU(@RequestBody MemberDTO memberDTO) throws Exception {
+        memberService.signUp(memberDTO);
+        return "sign-up success";
     }
+
 }

--- a/src/main/java/com/climbing/auth/jwt/JwtService.java
+++ b/src/main/java/com/climbing/auth/jwt/JwtService.java
@@ -1,0 +1,127 @@
+package com.climbing.auth.jwt;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.climbing.domain.member.MemberRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Getter
+@Slf4j
+public class JwtService {
+
+    @Value("${jwt.secretKey}")
+    private String secretKey;
+
+    @Value("${jwt.access.expiration}")
+    private Long accessTokenExpirationPeriod;
+
+    @Value("${jwt.refresh.expiration}")
+    private Long refreshTokenExpirationPeriod;
+
+    @Value("${jwt.access.header}")
+    private String accessHeader;
+
+    @Value("${jwt.refresh.header}")
+    private String refreshHeader;
+
+    private static final String ACCESS_TOKEN_SUBJECT = "AccessToken";
+    private static final String REFRESH_TOKEN_SUBJECT = "RefreshToken";
+    private static final String EMAIL_CLAIM = "email";
+    private static final String BEARER = "Bearer ";
+
+    private final MemberRepository memberRepository;
+
+    public String createAccessToken(String email) {
+        Date now = new Date();
+        return JWT.create()
+                .withSubject(ACCESS_TOKEN_SUBJECT)
+                .withExpiresAt(new Date(now.getTime() + accessTokenExpirationPeriod))
+                .withClaim(EMAIL_CLAIM, email)
+                .sign(Algorithm.HMAC512(secretKey));
+    }
+
+    public String createRefreshToken() {
+        Date now = new Date();
+        return JWT.create()
+                .withSubject(REFRESH_TOKEN_SUBJECT)
+                .withExpiresAt(new Date(now.getTime() + refreshTokenExpirationPeriod))
+                .sign(Algorithm.HMAC512(secretKey));
+    }
+
+    public void sendAccessToken(HttpServletResponse response, String accessToken) {
+        response.setStatus(HttpServletResponse.SC_OK);
+
+        response.setHeader(accessHeader, accessToken);
+        log.info("Access Token : {}", accessToken);
+    }
+
+    public void sendAccessTokenAndRefreshToken(HttpServletResponse response, String accessToken, String refreshToken) {
+        response.setStatus(HttpServletResponse.SC_OK);
+
+        setAccessTokenHeader(response, accessToken);
+        setRefreshTokenHeader(response, refreshToken);
+        log.info("Access Token, RefreshToken Header Complete");
+    }
+
+    public Optional<String> extractAccessToken(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader(accessHeader))
+                .filter(accessToken -> accessToken.startsWith(BEARER))
+                .map(accessToken -> accessToken.replace(BEARER, ""));
+    }
+
+    public Optional<String> extractRefreshToken(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader(refreshHeader))
+                .filter(refreshToken -> refreshToken.startsWith(BEARER))
+                .map(refreshToken -> refreshToken.replace(BEARER, ""));
+    }
+
+    public Optional<String> extractEmail(String accessToken) {
+        try {
+            return Optional.ofNullable(JWT.require(Algorithm.HMAC512(secretKey))
+                    .build()
+                    .verify(accessToken)
+                    .getClaim(EMAIL_CLAIM)
+                    .asString());
+        } catch (Exception e) {
+            log.error("유효하지 않은 토큰입니다.");
+            return Optional.empty();
+        }
+    }
+
+    public void setAccessTokenHeader(HttpServletResponse response, String accessToken) {
+        response.setHeader(accessHeader, accessToken);
+    }
+
+    public void setRefreshTokenHeader(HttpServletResponse response, String refreshToken) {
+        response.setHeader(refreshHeader, refreshToken);
+    }
+
+    public void updateRefreshToken(String email, String refreshToken) {
+        memberRepository.findByEmail(email)
+                .ifPresentOrElse(
+                        member -> member.updateRefreshToken(refreshToken),
+                        () -> new Exception("회원이 존재하지 않습니다.")
+                );
+    }
+
+    public boolean isTokenValid(String token) {
+        try {
+            JWT.require(Algorithm.HMAC512(secretKey)).build().verify(token);
+            return true;
+        } catch (Exception e) {
+            log.error("유효하지 않은 토큰입니다. {}", e.getMessage());
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/climbing/config/SecurityConfig.java
+++ b/src/main/java/com/climbing/config/SecurityConfig.java
@@ -1,0 +1,25 @@
+package com.climbing.config;
+
+import com.climbing.auth.jwt.JwtService;
+import com.climbing.domain.member.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final JwtService jwtService;
+    private final MemberRepository memberRepository;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+
+
+}

--- a/src/main/java/com/climbing/domain/member/Member.java
+++ b/src/main/java/com/climbing/domain/member/Member.java
@@ -1,10 +1,48 @@
 package com.climbing.domain.member;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Email;
+import lombok.*;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
+@Table(name = "MEMBER")
 @Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class Member {
+
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
     private Long id;
+
+    @Column(nullable = false, length = 30, unique = true)
+    @Email
+    private String email;
+
+    private String password;
+
+    @Column(nullable = false, length = 30, unique = true)
+    private String nickname;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    @Column(length = 1000)
+    private String refreshToken;
+
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    public void destroyRefreshToken() {
+        this.refreshToken = null;
+    }
+
+    // 비밀번호 암호화
+    public void encodePassword(PasswordEncoder passwordEncoder) {
+        this.password = passwordEncoder.encode(password);
+    }
 }

--- a/src/main/java/com/climbing/domain/member/MemberDTO.java
+++ b/src/main/java/com/climbing/domain/member/MemberDTO.java
@@ -1,0 +1,14 @@
+package com.climbing.domain.member;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class MemberDTO {
+    
+    private String email;
+    private String password;
+    private String nickname;
+
+}

--- a/src/main/java/com/climbing/domain/member/MemberRepository.java
+++ b/src/main/java/com/climbing/domain/member/MemberRepository.java
@@ -3,6 +3,13 @@ package com.climbing.domain.member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByEmail(String email);
+
+    Optional<Member> findByNickname(String nickname);
+
+    Optional<Member> findByRefreshToken(String refreshToken);
 }

--- a/src/main/java/com/climbing/domain/member/MemberService.java
+++ b/src/main/java/com/climbing/domain/member/MemberService.java
@@ -1,12 +1,36 @@
 package com.climbing.domain.member;
 
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
+@Transactional
+@RequiredArgsConstructor
 public class MemberService {
-    private MemberRepository memberRepository;
 
-    public MemberService(MemberRepository memberRepository) {
-        this.memberRepository = memberRepository;
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public void signUp(MemberDTO memberDTO) throws Exception {
+
+        if (memberRepository.findByEmail(memberDTO.getEmail()).isPresent()) {
+            throw new Exception("이미 존재하는 이메일입니다.");
+        }
+
+        if (memberRepository.findByNickname(memberDTO.getNickname()).isPresent()) {
+            throw new Exception("이미 존재하는 닉네임입니다.");
+        }
+
+        Member member = Member.builder()
+                .email(memberDTO.getEmail())
+                .password(memberDTO.getPassword())
+                .nickname(memberDTO.getNickname())
+                .role(Role.USER)
+                .build();
+
+        member.encodePassword(passwordEncoder);
+        memberRepository.save(member);
     }
 }

--- a/src/main/java/com/climbing/domain/member/Role.java
+++ b/src/main/java/com/climbing/domain/member/Role.java
@@ -1,0 +1,5 @@
+package com.climbing.domain.member;
+
+public enum Role {
+    USER, ADMIN
+}

--- a/src/main/resources/application-jwt.yaml
+++ b/src/main/resources/application-jwt.yaml
@@ -1,0 +1,12 @@
+jwt:
+  secretKey: 6719fb957c154661498bbe8ee5f9b301585ae89526f4f40f8d810182b01b5076
+
+  access:
+    expiration: 3600000 #1시간
+    header: Authorization
+
+  refresh:
+    expiration: 1209600000 # 2주
+    header: Authorization-refresh
+
+

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,8 +1,35 @@
 spring:
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+
   datasource:
     url: jdbc:h2:~/database
     driver-class-name: org.h2.Driver
+    username: climb
+    password: climb
+
   jpa:
     generate-ddl: 'true'
     hibernate:
       ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+        use_sql_comments: true
+
+  profiles:
+    include: jwt
+
+logging:
+  level:
+    org:
+      apache:
+        coyote:
+          http11: debug
+
+      hibernate:
+        SQL: debug
+
+

--- a/src/test/java/com/climbing/climbingbackend/auth/jwt/JwtServiceTest.java
+++ b/src/test/java/com/climbing/climbingbackend/auth/jwt/JwtServiceTest.java
@@ -1,0 +1,220 @@
+package com.climbing.climbingbackend.auth.jwt;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.climbing.auth.jwt.JwtService;
+import com.climbing.domain.member.Member;
+import com.climbing.domain.member.MemberRepository;
+import com.climbing.domain.member.Role;
+import jakarta.persistence.EntityManager;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+@Transactional
+public class JwtServiceTest {
+    @Autowired
+    JwtService jwtService;
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    EntityManager em;
+
+    @Value("${jwt.secretKey}")
+    private String secretKey;
+    @Value("${jwt.access.header}")
+    private String accessHeader;
+    @Value("${jwt.refresh.header}")
+    private String refreshHeader;
+
+    private static final String ACCESS_TOKEN_SUBJECT = "AccessToken";
+    private static final String REFRESH_TOKEN_SUBJECT = "RefreshToken";
+    private static final String EMAIL_CLAIM = "email";
+    private static final String BEARER = "Bearer ";
+
+    private final String email = "1234@1234.com";
+
+    @BeforeEach
+    public void init() {
+        Member member = Member.builder().email("1234@1234.com").password("12341234").nickname("tiger").role(Role.USER).build();
+        memberRepository.save(member);
+        clear();
+    }
+
+    private void clear() {
+        em.flush();
+        em.clear();
+    }
+
+    private DecodedJWT getVerify(String token) {
+        return JWT.require(Algorithm.HMAC512(secretKey)).build().verify(token);
+    }
+
+    @Test
+    @DisplayName("액세스 토큰 발급 테스트")
+    public void createAccessToken() throws Exception {
+        //given, when
+        String accessToken = jwtService.createAccessToken(email);
+        DecodedJWT verify = getVerify(accessToken);
+
+        String subject = verify.getSubject();
+        String findMemberEmail = verify.getClaim(EMAIL_CLAIM).asString();
+
+        //then
+        assertThat(findMemberEmail).isEqualTo(email);
+        assertThat(subject).isEqualTo(ACCESS_TOKEN_SUBJECT);
+    }
+
+    @Test
+    @DisplayName("리프레시 토큰 발급 테스트")
+    public void createRefreshToken() throws Exception {
+        //given, when
+        String refreshToken = jwtService.createRefreshToken();
+        DecodedJWT verify = getVerify(refreshToken);
+        String subject = verify.getSubject();
+        String email = verify.getClaim(EMAIL_CLAIM).asString();
+
+        //then
+        assertThat(subject).isEqualTo(REFRESH_TOKEN_SUBJECT);
+        assertThat(email).isNull();
+    }
+
+    @Test
+    @DisplayName("리프레시 토큰 업데이트 테스트")
+    public void updateRefreshToken() throws Exception {
+        //given
+        String refreshToken = jwtService.createRefreshToken();
+        jwtService.updateRefreshToken(email, refreshToken);
+        clear();
+        Thread.sleep(4000);
+
+        //when
+        String reCreateRefreshToken = jwtService.createRefreshToken();
+        jwtService.updateRefreshToken(email, reCreateRefreshToken);
+        clear();
+
+        //then
+        assertThrows(Exception.class, () -> memberRepository.findByRefreshToken(refreshToken).get());
+        assertThat(memberRepository.findByRefreshToken(reCreateRefreshToken).get().getEmail()).isEqualTo(email);
+    }
+
+    @Test
+    @DisplayName("액세스 토큰 헤더 설정 테스트")
+    public void setAccessTokenHeader() throws Exception {
+        MockHttpServletResponse mockHttpServletResponse = new MockHttpServletResponse();
+
+        String accessToken = jwtService.createAccessToken(email);
+        String refreshToken = jwtService.createRefreshToken();
+
+        jwtService.setAccessTokenHeader(mockHttpServletResponse, accessToken);
+
+        //when
+        jwtService.sendAccessTokenAndRefreshToken(mockHttpServletResponse, accessToken, refreshToken);
+
+        //then
+        String headerAccessToken = mockHttpServletResponse.getHeader(accessHeader);
+
+        assertThat(headerAccessToken).isEqualTo(accessToken);
+    }
+
+    @Test
+    @DisplayName("리프레시 토큰 헤더 설정 테스트")
+    public void setRefreshTokenHeader() throws Exception {
+        MockHttpServletResponse mockHttpServletResponse = new MockHttpServletResponse();
+
+        String accessToken = jwtService.createAccessToken(email);
+        String refreshToken = jwtService.createRefreshToken();
+
+        jwtService.setRefreshTokenHeader(mockHttpServletResponse, refreshToken);
+
+        //when
+        jwtService.sendAccessTokenAndRefreshToken(mockHttpServletResponse, accessToken, refreshToken);
+
+        //then
+        String headerRefreshToken = mockHttpServletResponse.getHeader(refreshHeader);
+
+        assertThat(headerRefreshToken).isEqualTo(refreshToken);
+    }
+
+    private HttpServletRequest setRequest(String accessToken, String refreshToken) throws IOException {
+
+        MockHttpServletResponse mockHttpServletResponse = new MockHttpServletResponse();
+        jwtService.sendAccessTokenAndRefreshToken(mockHttpServletResponse, accessToken, refreshToken);
+
+        String headerAccessToken = mockHttpServletResponse.getHeader(accessHeader);
+        String headerRefreshToken = mockHttpServletResponse.getHeader(refreshHeader);
+
+        MockHttpServletRequest httpServletRequest = new MockHttpServletRequest();
+
+        httpServletRequest.addHeader(accessHeader, BEARER + headerAccessToken);
+        httpServletRequest.addHeader(refreshHeader, BEARER + headerRefreshToken);
+
+        return httpServletRequest;
+    }
+
+
+    @Test
+    @DisplayName("액세스 토큰 추출 테스트")
+    public void extractAccessToken() throws Exception {
+        //given
+        String accessToken = jwtService.createAccessToken(email);
+        String refreshToken = jwtService.createRefreshToken();
+        HttpServletRequest httpServletRequest = setRequest(accessToken, refreshToken);
+
+        //when
+        String extractAccessToken = jwtService.extractAccessToken(httpServletRequest).get();
+
+        //then
+        assertThat(extractAccessToken).isEqualTo(accessToken);
+        assertThat(getVerify(extractAccessToken).getClaim(EMAIL_CLAIM).asString()).isEqualTo(email);
+
+    }
+
+    @Test
+    @DisplayName("리프레시 토큰 추출 테스트")
+    public void extractRefreshToken() throws Exception {
+        //given
+        String accessToken = jwtService.createAccessToken(email);
+        String refreshToken = jwtService.createRefreshToken();
+        HttpServletRequest httpServletRequest = setRequest(accessToken, refreshToken);
+
+        //when
+        String extractRefreshToken = jwtService.extractRefreshToken(httpServletRequest).get();
+
+        //then
+        assertThat(extractRefreshToken).isEqualTo(refreshToken);
+        assertThat(getVerify(extractRefreshToken).getSubject()).isEqualTo(REFRESH_TOKEN_SUBJECT);
+    }
+
+    @Test
+    @DisplayName("이메일 추출 테스트")
+    public void extractEmail() throws Exception {
+        //given
+        String accessToken = jwtService.createAccessToken(email);
+        String refreshToken = jwtService.createRefreshToken();
+        HttpServletRequest httpServletRequest = setRequest(accessToken, refreshToken);
+        String requestAccessToken = jwtService.extractAccessToken(httpServletRequest).get();
+
+        //when
+        String extractEmail = jwtService.extractEmail(requestAccessToken).get();
+
+        //then
+        assertThat(extractEmail).isEqualTo(email);
+    }
+
+
+}

--- a/src/test/java/com/climbing/climbingbackend/domain/member/MemberRepositoryTest.java
+++ b/src/test/java/com/climbing/climbingbackend/domain/member/MemberRepositoryTest.java
@@ -1,0 +1,76 @@
+package com.climbing.climbingbackend.domain.member;
+
+import com.climbing.domain.member.Member;
+import com.climbing.domain.member.MemberRepository;
+import com.climbing.domain.member.Role;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+@Transactional
+class MemberRepositoryTest {
+
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    EntityManager em;
+
+    @AfterEach
+    public void after() {
+        em.clear();
+    }
+
+    @Test
+    @DisplayName("회원 가입")
+    public void saveMember() throws Exception {
+        //given
+        Member member = Member.builder().email("1234@1234.com").password("12341234").nickname("tiger").role(Role.USER).build();
+
+        //when
+        Member saveMember = memberRepository.save(member);
+
+        //then
+        Member findMember = memberRepository.findById(saveMember.getId()).orElseThrow(() -> new RuntimeException("저장을 실패하였습니다."));
+
+        assertThat(findMember).isSameAs(saveMember);
+        assertThat(findMember).isSameAs(member);
+    }
+
+    @Test
+    @DisplayName("중복된 이메일로 회원 가입시 오류")
+    public void duplicateMember() throws Exception {
+        //given
+        Member member = Member.builder().email("1234@1234.com").password("12341234").nickname("tiger").role(Role.USER).build();
+        Member member2 = Member.builder().email("1234@1234.com").password("12341234").nickname("lion").role(Role.USER).build();
+        memberRepository.save(member);
+        after();
+
+        //when, then
+        assertThrows(Exception.class, () -> memberRepository.save(member2));
+    }
+
+    @Test
+    @DisplayName("멤버 찾기 테스트")
+    public void findMember() throws Exception {
+        //given
+        String email = "1234@1234.com";
+        Member member = Member.builder().email("1234@1234.com").password("12341234").nickname("tiger").role(Role.USER).build();
+        memberRepository.save(member);
+        after();
+
+        //when, then
+        assertThat(memberRepository.findByEmail(email).get().getEmail()).isEqualTo(member.getEmail());
+        assertThat(memberRepository.findByEmail(email).get().getNickname()).isEqualTo(member.getNickname());
+        assertThrows(Exception.class,
+                () -> memberRepository.findByEmail("12345@1234.com").orElseThrow(Exception::new));
+    }
+
+}


### PR DESCRIPTION
- 멤버 회원가입 Api 구현 및 JWT 로그인을 위한 Access token, Refresh token 발급, 재발급 구현
- 추가로 jwt 인증 , OAth2.0 로그인은 현재 개발 진행 중입니다.
- 회원 수정, 회원 탈퇴 구현도 개발 진행 중입니다.
- 회원 정보에 추가로 필요한 정보는 상의 후 추가 예정입니다. (주소, 이미지, 나이, 성별 등등)
